### PR TITLE
Fixed client_generate_hashed_key with emscripten generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+python/include
+python/_bsspeke*
+python/tmp.h
+
+*.o
+*.a
+EmccBsspeke.*
+demo

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,24 @@
+CC = cc
+CFLAGS = -Wall
+
 default: demo
 
 lib: libbsspeke.a
 
 monocypher.o: monocypher.c monocypher.h
-	cc -c monocypher.c -fPIC
+	${CC} ${CFLAGS} -c monocypher.c -fPIC
 
 bsspeke.o: bsspeke.c include/bsspeke.h monocypher.h
-	cc -c bsspeke.c -fPIC
+	${CC} ${CFLAGS} -c bsspeke.c -fPIC
 
 libbsspeke.a: bsspeke.o monocypher.o
 	ar rcs libbsspeke.a bsspeke.o monocypher.o
 
 demo.o: demo.c include/bsspeke.h
-	cc -c demo.c -fPIC
+	${CC} ${CFLAGS} -c demo.c -fPIC
 
 demo: demo.o libbsspeke.a
-	cc -o demo demo.o -L. -lbsspeke -fPIC
+	${CC} ${CFLAGS} -o demo demo.o -L. -lbsspeke -fPIC
 
 clean:
 	rm -f demo demo.o bsspeke.o monocypher.o libbsspeke.a

--- a/bsspeke.c
+++ b/bsspeke.c
@@ -26,12 +26,12 @@
 
 /*
 For Emscripten compilation to Javascript use the following:
-./emcc bsspeke.c monocypher.c -s EXPORT_ALL=1 -s EXPORTED_FUNCTIONS=_malloc,_free -s EXPORTED_RUNTIME_METHODS=ccall -s ALLOW_MEMORY_GROWTH
+emcc bsspeke.c monocypher.c -s EXPORT_ALL=1 -s EXPORTED_FUNCTIONS=_malloc,_free -s EXPORTED_RUNTIME_METHODS=ccall -s ALLOW_MEMORY_GROWTH -s EXPORT_ES6=1 -s MODULARIZE=1 -o EmccBsspeke.js
 
 This will export all functions with the macro EMSCRIPTEN_KEEPALIVE, free and
 malloc, and the emscripten ccall. If you want to shorten the list of exported
 functions and the file size, you can remove some macros from function
-definitions.
+definitions. Add -O3 flag for release build
 */
 #if defined(EMSCRIPTEN)
 #include "syscall.h"
@@ -410,13 +410,19 @@ int bsspeke_client_generate_master_key(
 
 #ifdef EMSCRIPTEN
 EMSCRIPTEN_KEEPALIVE
+uint8_t *
+#else
+void
 #endif
-void bsspeke_client_generate_hashed_key(
+bsspeke_client_generate_hashed_key(
     uint8_t k[32],
     const uint8_t *msg, size_t msg_len,
     bsspeke_client_ctx *client)
 {
     crypto_blake2b_keyed(k, 32, client->K_password, 32, msg, msg_len);
+#ifdef EMSCRIPTEN
+    return (uint8_t *)k;
+#endif
 }
 
 void bsspeke_client_generate_internal_key(

--- a/include/bsspeke.h
+++ b/include/bsspeke.h
@@ -2,7 +2,7 @@
  * bsspeke.h - BS-SPEKE over Curve25519
  *
  * Author: Charles V. Wright <cvwright@futo.org>
- * 
+ *
  * Copyright (c) 2022 FUTO Holdings, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -76,7 +76,7 @@ typedef struct {
 
     uint8_t b[32];           // Ephemeral private key
     uint8_t B[32];           // Ephemeral public key
-    
+
     uint8_t A[32];           // Client's ephemeral public key
 
     uint8_t K_s[32];         // Session key
@@ -95,11 +95,11 @@ int
 bsspeke_server_init(bsspeke_server_ctx *ctx,
                     const char* server_id, const size_t server_id_len,
                     const char* client_id, const size_t client_id_len);
-                    
+
 #ifdef EMSCRIPTEN
 uint8_t*
 #else
-void 
+void
 #endif
 bsspeke_client_generate_blind(
     uint8_t blind[32],
@@ -119,7 +119,11 @@ void
 bsspeke_server_get_B(uint8_t B[32],
                      bsspeke_server_ctx *server);
 
+#ifdef EMSCRIPTEN
+uint8_t*
+#else
 void
+#endif
 bsspeke_client_generate_hashed_key(uint8_t k[32],
                                    const uint8_t *msg, size_t msg_len,
                                    bsspeke_client_ctx *client);


### PR DESCRIPTION
Fixing `bsspeke_client_generate_hashed_key` allows for Swiclops backup key decryption in web clients.